### PR TITLE
Add support for choosing next/prev subtitle lines using g/y keys.

### DIFF
--- a/source/controllers/PlayerController.h
+++ b/source/controllers/PlayerController.h
@@ -167,6 +167,8 @@
 - (NSMenu *)contextMenu;
 
 - (IBAction)cycleOSD:(id)sender;
+- (IBAction)nextSubtitleLine:(id)sender;
+- (IBAction)prevSubtitleLine:(id)sender;
 - (void)setAudioDelay:(float)delay relative:(BOOL)setRelative;
 - (void)setSubtitleDelay:(float)delay relative:(BOOL)setRelative;
 - (void)setPlaybackSpeed:(float)speed multiply:(BOOL)multiply;

--- a/source/controllers/PlayerController.m
+++ b/source/controllers/PlayerController.m
@@ -1237,6 +1237,17 @@
 	[[movieInfo prefs] setInteger:osdLevel forKey:MPEOSDLevel];
 }
 
+/************************************************************************************/
+- (void)prevSubtitleLine:(id)sender
+{
+	[myPlayer sendCommand:@"sub_step -1"];
+}
+
+- (void)nextSubtitleLine:(id)sender
+{
+	[myPlayer sendCommand:@"sub_step +1"];
+}
+
 #pragma mark - Delay
 /************************************************************************************/
 - (void)setAudioDelay:(float)delay relative:(BOOL)setRelative {
@@ -1843,6 +1854,12 @@
 	// Cycle OSD
 	else if ((keyHandled = [characters isEqualToString:@"o"]))
 		[self cycleOSD:self];
+
+	// Subtitles fixups
+	else if ((keyHandled = [characters isEqualToString:@"y"]))
+		[self nextSubtitleLine:self];
+	else if ((keyHandled = [characters isEqualToString:@"g"]))
+		[self prevSubtitleLine:self];
 	
 	// Audio Delay
 	else if ((keyHandled = ([characters isEqualToString:@"+"]


### PR DESCRIPTION
Mplayer have used g/y keys to choose prev/next subtitle line
for a long time. MPlayer OSX Extended have the same ability
up to rev12 and then the functionality disappeared. This
patch restores the ability to use g/y because it is a very
useful way to sync subtitles that are a little bit off.

Signed-Off-By: Georgi Chorbadzhiyski georgi@unixsol.org
