### PR TITLE
Show volume in the OSD on change.

### DIFF
--- a/source/core/MPlayerInterface.m
+++ b/source/core/MPlayerInterface.m
@@ -912,11 +912,17 @@ static NSArray* statusNames;
 	if ([[playingItem prefs] objectForKey:MPEAudioItemRelativeVolume])
 		volume *= [[playingItem prefs] floatForKey:MPEAudioItemRelativeVolume];
 	
-	if (playerMute)
+	osdLevel = [[playingItem prefs] integerForKey:MPEOSDLevel];
+	if (playerMute) {
 		[self sendCommand:[NSString stringWithFormat:@"set_property mute %d", playerMute]];
-	else
+		if (osdLevel == 1 || osdLevel == 2)
+			[self sendCommand:@"osd_show_property_text Mute"];
+	} else {
 		[self sendCommand:[NSString stringWithFormat:@"set_property volume %.2f", volume]];
-	
+		if (osdLevel == 1 || osdLevel == 2)
+			[self sendCommand:[NSString stringWithFormat:@"osd_show_property_text 'Volume: %3.0f%%'", volume]];
+	}
+
 	// Inform clients of change
 	[self notifyClientsWithSelector:@selector(interface:volumeUpdate:isMuted:) 
 						  andObject:[NSNumber numberWithFloat:volume]


### PR DESCRIPTION
Without this the only way to see the volume value is
to watch volume slider but this is hardly exact.

Volume and Mute messages are enabled only when OSD
is set to "Subtitles, Messages" or "Subtitles, Messages,
Status Bars".

Signed-off-by: Georgi Chorbadzhiyski georgi@unixsol.org
