### PR TITLE
added <objc/runtime.h> to CocoaAdditions.m make it compile on 10.8

### DIFF
--- a/source/util/CocoaAdditions.m
+++ b/source/util/CocoaAdditions.m
@@ -24,6 +24,7 @@
 
 #import "CocoaAdditions.h"
 #import <AppKit/NSView.h>
+#include <objc/runtime.h>
 
 #include <iconv.h>
 


### PR DESCRIPTION
added <objc/runtime.h> to CocoaAdditions.m make it compile on 10.8

Any progress on releasing the next version?
